### PR TITLE
Fix height mismatch in input elements

### DIFF
--- a/main.css
+++ b/main.css
@@ -32,6 +32,11 @@
     font-size: 2vw;
 }
 
+.large > .input-group-addon {
+  padding-top: 3px;
+  padding-bottom: 3px;
+}
+
 .relative {
     position: relative;
 }


### PR DESCRIPTION
In full(or large width) screen, font size of input-group-addon is too higher than input element(form-control.input-lg) because font size is 2vw in inner of the .large class elements.

| before | after |
| --- | --- |
| <img width="465" alt="2017-03-28 19 37 22" src="https://cloud.githubusercontent.com/assets/4487291/24401143/1d1d8c4e-13ee-11e7-8f4a-dfdaf0c7da46.png"> | <img width="460" alt="2017-03-28 19 37 33" src="https://cloud.githubusercontent.com/assets/4487291/24401150/234af0d4-13ee-11e7-9538-5c7bc5b93e35.png"> |